### PR TITLE
convert the date information in file_names.csv

### DIFF
--- a/get_file_names.py
+++ b/get_file_names.py
@@ -40,6 +40,7 @@ def open_with_csv(curr_csv_name, arch_csv_name, csv_out_name, do_print):
                         cscreenshot_status = crow[-1]
                         [aarchive_id, aurl_id, adate, aurl] = arow[:4]
                         ascreenshot_status = arow[-1]
+                        ascreenshot_site_message = arow[-2]
 
                         curl_id = int(curl_id)
                         aurl_id = int(aurl_id)
@@ -49,6 +50,13 @@ def open_with_csv(curr_csv_name, arch_csv_name, csv_out_name, do_print):
                         elif curl_id < aurl_id or cscreenshot_status != "Screenshot successful":
                             crow = next(curr_csv_reader)
                         else:
+                            if (ascreenshot_site_message.find("Redirected") == 0):
+                                aurl = ascreenshot_site_message.split()[2]
+                                marker = aarchive_id+'/'
+                                aurl_split = aurl.split(marker)[1]
+                                adate = aurl_split[:aurl_split.find('/')]
+                                if (adate.find("if_") != -1):
+                                    adate = adate[:-3]
                             current_filename = "{0}.{1}.jpg".format(carchive_id, curl_id)
                             archive_filename = "{0}.{1}.{2}.jpg".format(aarchive_id, aurl_id, adate)
                             csv_writer.writerow([curl, aurl, current_filename, archive_filename])


### PR DESCRIPTION
Hello Brenda,

In this pull request, the dates information in the file_names.csv (the output file of get_file_names.py) are converted to the dates information of the redirect URLs.

Here are some details:
Before making changes, get_file_names.py extracts the date information from archive_index.csv (the output file of archive_screenshot.py) to form the name of the screenshot file. However, for redirected urls, the date information extracted from archive_index.csv does not match the actual date information contained in the screenshot name. These will cause errors when we test calculate_similarity.py.

In this pull request, I used site_messages in archive_index.csv and checked if the URL was redirected to another URL. If so, get_file_names.py will use the date information of the redirected url to form the file name instead of the original date information. The changes are made around lines 43, 53-59 in get_file_names.py.

Have a nice day!

Regards,

Qiufeng